### PR TITLE
Refactor/fix Prometheus metrics for multiple connection pools, add un…

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTrackerFactory.java
@@ -5,7 +5,8 @@ import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
 import com.zaxxer.hikari.metrics.PoolStats;
 import io.micrometer.core.instrument.MeterRegistry;
 
-public class MicrometerMetricsTrackerFactory implements MetricsTrackerFactory {
+public class MicrometerMetricsTrackerFactory implements MetricsTrackerFactory
+{
 
    private final MeterRegistry registry;
 

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollector.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollector.java
@@ -12,13 +12,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.zaxxer.hikari.metrics.prometheus;
 
 import com.zaxxer.hikari.metrics.PoolStats;
 import io.prometheus.client.Collector;
 import io.prometheus.client.GaugeMetricFamily;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -26,14 +27,16 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
-class HikariCPCollector extends Collector {
+class HikariCPCollector extends Collector
+{
 
    private static final List<String> LABEL_NAMES = Collections.singletonList("pool");
 
    private final Map<String, PoolStats> poolStatsMap = new ConcurrentHashMap<>();
 
    @Override
-   public List<MetricFamilySamples> collect() {
+   public List<MetricFamilySamples> collect()
+   {
       return Arrays.asList(
          createGauge("hikaricp_active_connections", "Active connections",
             PoolStats::getActiveConnections),
@@ -50,13 +53,19 @@ class HikariCPCollector extends Collector {
       );
    }
 
-   protected HikariCPCollector add(String name, PoolStats poolStats) {
+   void add(String name, PoolStats poolStats)
+   {
       poolStatsMap.put(name, poolStats);
-      return this;
+   }
+
+   void remove(String name)
+   {
+      poolStatsMap.remove(name);
    }
 
    private GaugeMetricFamily createGauge(String metric, String help,
-      Function<PoolStats, Integer> metricValueFunction) {
+                                         Function<PoolStats, Integer> metricValueFunction)
+   {
       GaugeMetricFamily metricFamily = new GaugeMetricFamily(metric, help, LABEL_NAMES);
       poolStatsMap.forEach((k, v) -> metricFamily.addMetric(
          Collections.singletonList(k),

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
@@ -12,66 +12,69 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.zaxxer.hikari.metrics.prometheus;
 
 import com.zaxxer.hikari.metrics.IMetricsTracker;
+import com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory.RegistrationStatus;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Summary;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+
+import static com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory.RegistrationStatus.REGISTERED;
 
 class PrometheusMetricsTracker implements IMetricsTracker
 {
-   private final Counter CONNECTION_TIMEOUT_COUNTER = Counter.build()
+   private final static Counter CONNECTION_TIMEOUT_COUNTER = Counter.build()
       .name("hikaricp_connection_timeout_total")
       .labelNames("pool")
       .help("Connection timeout total count")
       .create();
 
-   private final Summary ELAPSED_ACQUIRED_SUMMARY =
-      registerSummary("hikaricp_connection_acquired_nanos", "Connection acquired time (ns)");
+   private final static Summary ELAPSED_ACQUIRED_SUMMARY =
+      createSummary("hikaricp_connection_acquired_nanos", "Connection acquired time (ns)");
 
-   private final Summary ELAPSED_BORROWED_SUMMARY =
-      registerSummary("hikaricp_connection_usage_millis", "Connection usage (ms)");
+   private final static Summary ELAPSED_USAGE_SUMMARY =
+      createSummary("hikaricp_connection_usage_millis", "Connection usage (ms)");
 
-   private final Summary ELAPSED_CREATION_SUMMARY =
-      registerSummary("hikaricp_connection_creation_millis", "Connection creation (ms)");
+   private final static Summary ELAPSED_CREATION_SUMMARY =
+      createSummary("hikaricp_connection_creation_millis", "Connection creation (ms)");
+
+   private final static Map<CollectorRegistry, RegistrationStatus> registrationStatuses = new ConcurrentHashMap<>();
+
+   private final String poolName;
+   private final HikariCPCollector hikariCPCollector;
 
    private final Counter.Child connectionTimeoutCounterChild;
 
-   private Summary registerSummary(String name, String help) {
-      return Summary.build()
-         .name(name)
-         .labelNames("pool")
-         .help(help)
-         .quantile(0.5, 0.05)
-         .quantile(0.95, 0.01)
-         .quantile(0.99, 0.001)
-         .maxAgeSeconds(TimeUnit.MINUTES.toSeconds(5))
-         .ageBuckets(5)
-         .create();
-   }
-
    private final Summary.Child elapsedAcquiredSummaryChild;
-   private final Summary.Child elapsedBorrowedSummaryChild;
+   private final Summary.Child elapsedUsageSummaryChild;
    private final Summary.Child elapsedCreationSummaryChild;
 
-   PrometheusMetricsTracker(String poolName, CollectorRegistry collectorRegistry) {
+   PrometheusMetricsTracker(String poolName, CollectorRegistry collectorRegistry, HikariCPCollector hikariCPCollector)
+   {
       registerMetrics(collectorRegistry);
+      this.poolName = poolName;
+      this.hikariCPCollector = hikariCPCollector;
       this.connectionTimeoutCounterChild = CONNECTION_TIMEOUT_COUNTER.labels(poolName);
       this.elapsedAcquiredSummaryChild = ELAPSED_ACQUIRED_SUMMARY.labels(poolName);
-      this.elapsedBorrowedSummaryChild = ELAPSED_BORROWED_SUMMARY.labels(poolName);
+      this.elapsedUsageSummaryChild = ELAPSED_USAGE_SUMMARY.labels(poolName);
       this.elapsedCreationSummaryChild = ELAPSED_CREATION_SUMMARY.labels(poolName);
    }
 
-   private void registerMetrics(CollectorRegistry collectorRegistry){
-      CONNECTION_TIMEOUT_COUNTER.register(collectorRegistry);
-      ELAPSED_ACQUIRED_SUMMARY.register(collectorRegistry);
-      ELAPSED_BORROWED_SUMMARY.register(collectorRegistry);
-      ELAPSED_CREATION_SUMMARY.register(collectorRegistry);
+   private void registerMetrics(CollectorRegistry collectorRegistry)
+   {
+      if (registrationStatuses.putIfAbsent(collectorRegistry, REGISTERED) == null) {
+         CONNECTION_TIMEOUT_COUNTER.register(collectorRegistry);
+         ELAPSED_ACQUIRED_SUMMARY.register(collectorRegistry);
+         ELAPSED_USAGE_SUMMARY.register(collectorRegistry);
+         ELAPSED_CREATION_SUMMARY.register(collectorRegistry);
+      }
    }
 
    @Override
@@ -83,7 +86,7 @@ class PrometheusMetricsTracker implements IMetricsTracker
    @Override
    public void recordConnectionUsageMillis(long elapsedBorrowedMillis)
    {
-      elapsedBorrowedSummaryChild.observe(elapsedBorrowedMillis);
+      elapsedUsageSummaryChild.observe(elapsedBorrowedMillis);
    }
 
    @Override
@@ -96,5 +99,29 @@ class PrometheusMetricsTracker implements IMetricsTracker
    public void recordConnectionTimeout()
    {
       connectionTimeoutCounterChild.inc();
+   }
+
+   private static Summary createSummary(String name, String help)
+   {
+      return Summary.build()
+         .name(name)
+         .labelNames("pool")
+         .help(help)
+         .quantile(0.5, 0.05)
+         .quantile(0.95, 0.01)
+         .quantile(0.99, 0.001)
+         .maxAgeSeconds(TimeUnit.MINUTES.toSeconds(5))
+         .ageBuckets(5)
+         .create();
+   }
+
+   @Override
+   public void close()
+   {
+      hikariCPCollector.remove(poolName);
+      CONNECTION_TIMEOUT_COUNTER.remove(poolName);
+      ELAPSED_ACQUIRED_SUMMARY.remove(poolName);
+      ELAPSED_USAGE_SUMMARY.remove(poolName);
+      ELAPSED_CREATION_SUMMARY.remove(poolName);
    }
 }

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
@@ -12,59 +12,78 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.zaxxer.hikari.metrics.prometheus;
 
 import com.zaxxer.hikari.metrics.IMetricsTracker;
 import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
 import com.zaxxer.hikari.metrics.PoolStats;
+import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory.RegistrationStatus.REGISTERED;
 
 /**
  * <pre>{@code
  * HikariConfig config = new HikariConfig();
  * config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
  * }</pre>
+ * or
+ * <pre>{@code
+ * config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(new CollectorRegistry()));
+ * }</pre>
  *
  * Note: the internal {@see io.prometheus.client.Summary} requires heavy locks. Consider using
  * {@see PrometheusHistogramMetricsTrackerFactory} if performance plays a role and you don't need the summary per se.
  */
-public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
+public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory
+{
 
-   private HikariCPCollector collector;
+   private final static Map<CollectorRegistry, RegistrationStatus> registrationStatuses = new ConcurrentHashMap<>();
 
-   private CollectorRegistry collectorRegistry;
+   private final HikariCPCollector collector = new HikariCPCollector();
+
+   private final CollectorRegistry collectorRegistry;
+
+   public enum RegistrationStatus
+   {
+      REGISTERED;
+   }
 
    /**
     * Default Constructor. The Hikari metrics are registered to the default
     * collector registry ({@code CollectorRegistry.defaultRegistry}).
     */
-   public PrometheusMetricsTrackerFactory() {
-      this.collectorRegistry = CollectorRegistry.defaultRegistry;
+   public PrometheusMetricsTrackerFactory()
+   {
+      this(CollectorRegistry.defaultRegistry);
    }
 
    /**
     * Constructor that allows to pass in a {@link CollectorRegistry} to which the
     * Hikari metrics are registered.
     */
-   public PrometheusMetricsTrackerFactory(CollectorRegistry collectorRegistry) {
+   public PrometheusMetricsTrackerFactory(CollectorRegistry collectorRegistry)
+   {
       this.collectorRegistry = collectorRegistry;
    }
 
    @Override
-   public IMetricsTracker create(String poolName, PoolStats poolStats) {
-      getCollector().add(poolName, poolStats);
-      return new PrometheusMetricsTracker(poolName, this.collectorRegistry);
+   public IMetricsTracker create(String poolName, PoolStats poolStats)
+   {
+      registerCollector(this.collector, this.collectorRegistry);
+      this.collector.add(poolName, poolStats);
+      return new PrometheusMetricsTracker(poolName, this.collectorRegistry, this.collector);
    }
 
-   /**
-    * initialize and register collector if it isn't initialized yet
-    */
-   private HikariCPCollector getCollector() {
-      if (collector == null) {
-         collector = new HikariCPCollector().register(this.collectorRegistry);
+   private void registerCollector(Collector collector, CollectorRegistry collectorRegistry)
+   {
+      if (registrationStatuses.putIfAbsent(collectorRegistry, REGISTERED) == null) {
+         collector.register(collectorRegistry);
       }
-      return collector;
    }
 }

--- a/src/test/java/com/zaxxer/hikari/metrics/dropwizard/CodaHaleMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/dropwizard/CodaHaleMetricsTrackerTest.java
@@ -1,18 +1,18 @@
 package com.zaxxer.hikari.metrics.dropwizard;
 
-import static org.mockito.Mockito.verify;
-
-import com.zaxxer.hikari.metrics.PoolStats;
+import com.codahale.metrics.MetricRegistry;
+import com.zaxxer.hikari.mocks.StubPoolStats;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.codahale.metrics.MetricRegistry;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CodaHaleMetricsTrackerTest {
+public class CodaHaleMetricsTrackerTest
+{
 
    @Mock
    public MetricRegistry mockMetricRegistry;
@@ -20,12 +20,14 @@ public class CodaHaleMetricsTrackerTest {
    private CodaHaleMetricsTracker testee;
 
    @Before
-   public void setup() {
-      testee = new CodaHaleMetricsTracker("mypool", poolStats(), mockMetricRegistry);
+   public void setup()
+   {
+      testee = new CodaHaleMetricsTracker("mypool", new StubPoolStats(0), mockMetricRegistry);
    }
 
    @Test
-   public void close() throws Exception {
+   public void close()
+   {
       testee.close();
 
       verify(mockMetricRegistry).remove("mypool.pool.Wait");
@@ -38,14 +40,5 @@ public class CodaHaleMetricsTrackerTest {
       verify(mockMetricRegistry).remove("mypool.pool.PendingConnections");
       verify(mockMetricRegistry).remove("mypool.pool.MaxConnections");
       verify(mockMetricRegistry).remove("mypool.pool.MinConnections");
-   }
-
-   private PoolStats poolStats() {
-      return new PoolStats(0) {
-         @Override
-         protected void update() {
-            // do nothing
-         }
-      };
    }
 }

--- a/src/test/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTrackerTest.java
@@ -1,30 +1,28 @@
 package com.zaxxer.hikari.metrics.micrometer;
 
-import com.zaxxer.hikari.metrics.PoolStats;
+import com.zaxxer.hikari.mocks.StubPoolStats;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MicrometerMetricsTrackerTest {
+public class MicrometerMetricsTrackerTest
+{
 
    private MeterRegistry mockMeterRegistry = new SimpleMeterRegistry();
 
    private MicrometerMetricsTracker testee;
 
    @Before
-   public void setup(){
-      testee = new MicrometerMetricsTracker("mypool", new PoolStats(1000L) {
-         @Override
-         protected void update() {
-            // nothing
-         }
-      }, mockMeterRegistry);
+   public void setup()
+   {
+      testee = new MicrometerMetricsTracker("mypool", new StubPoolStats(1000L), mockMeterRegistry);
    }
 
    @Test
-   public void close() throws Exception {
+   public void close()
+   {
       Assert.assertNotNull(mockMeterRegistry.find("hikaricp.connections.acquire").tag("pool", "mypool").timer());
       Assert.assertNotNull(mockMeterRegistry.find("hikaricp.connections.usage").tag("pool", "mypool").timer());
       Assert.assertNotNull(mockMeterRegistry.find("hikaricp.connections.creation").tag("pool", "mypool").timer());

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollectorTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollectorTest.java
@@ -19,10 +19,14 @@ package com.zaxxer.hikari.metrics.prometheus;
 import static com.zaxxer.hikari.pool.TestElf.newHikariConfig;
 import static com.zaxxer.hikari.util.UtilityElf.quietlySleep;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import java.sql.Connection;
+import java.util.List;
 
+import com.zaxxer.hikari.metrics.PoolStats;
+import io.prometheus.client.Collector;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,18 +36,20 @@ import com.zaxxer.hikari.mocks.StubConnection;
 
 import io.prometheus.client.CollectorRegistry;
 
-public class HikariCPCollectorTest {
+public class HikariCPCollectorTest
+{
 
    private CollectorRegistry collectorRegistry;
 
    @Before
-   public void setupCollectorRegistry(){
+   public void setupCollectorRegistry()
+   {
       this.collectorRegistry = new CollectorRegistry();
    }
 
-
    @Test
-   public void noConnection() throws Exception {
+   public void noConnection()
+   {
       HikariConfig config = newHikariConfig();
       config.setMinimumIdle(0);
       config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
@@ -64,7 +70,8 @@ public class HikariCPCollectorTest {
    }
 
    @Test
-   public void noConnectionWithoutPoolName() throws Exception {
+   public void noConnectionWithoutPoolName()
+   {
       HikariConfig config = new HikariConfig();
       config.setMinimumIdle(0);
       config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
@@ -86,7 +93,8 @@ public class HikariCPCollectorTest {
    }
 
    @Test
-   public void connection1() throws Exception {
+   public void connection1() throws Exception
+   {
       HikariConfig config = newHikariConfig();
       config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
       config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
@@ -111,7 +119,8 @@ public class HikariCPCollectorTest {
    }
 
    @Test
-   public void connectionClosed() throws Exception {
+   public void connectionClosed() throws Exception
+   {
       HikariConfig config = newHikariConfig();
       config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
       config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
@@ -135,10 +144,78 @@ public class HikariCPCollectorTest {
       }
    }
 
-   private double getValue(String name, String poolName) {
+   @Test
+   public void poolStatsRemovedAfterShutDown() throws Exception
+   {
+      HikariConfig config = new HikariConfig();
+      config.setPoolName("shutDownPool");
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+      config.setMaximumPoolSize(1);
+
+      StubConnection.slowCreate = true;
+      try (HikariDataSource ds = new HikariDataSource(config)) {
+         try (Connection connection1 = ds.getConnection()) {
+            // close immediately
+         }
+
+         assertThat(getValue("hikaricp_active_connections", "shutDownPool"), is(0.0));
+         assertThat(getValue("hikaricp_idle_connections", "shutDownPool"), is(1.0));
+         assertThat(getValue("hikaricp_pending_threads", "shutDownPool"), is(0.0));
+         assertThat(getValue("hikaricp_connections", "shutDownPool"), is(1.0));
+         assertThat(getValue("hikaricp_max_connections", "shutDownPool"), is(1.0));
+         assertThat(getValue("hikaricp_min_connections", "shutDownPool"), is(1.0));
+      }
+      finally {
+         StubConnection.slowCreate = false;
+      }
+
+      assertNull(getValue("hikaricp_active_connections", "shutDownPool"));
+      assertNull(getValue("hikaricp_idle_connections", "shutDownPool"));
+      assertNull(getValue("hikaricp_pending_threads", "shutDownPool"));
+      assertNull(getValue("hikaricp_connections", "shutDownPool"));
+      assertNull(getValue("hikaricp_max_connections", "shutDownPool"));
+      assertNull(getValue("hikaricp_min_connections", "shutDownPool"));
+   }
+
+   @Test
+   public void testHikariCPCollectorGaugesMetricsInitialization()
+   {
+      HikariCPCollector hikariCPCollector = new HikariCPCollector();
+      hikariCPCollector.add("collectorTestPool", poolStatsWithPredefinedValues());
+      List<Collector.MetricFamilySamples> metrics = hikariCPCollector.collect();
+      hikariCPCollector.register(collectorRegistry);
+
+      assertThat(metrics.size(), is(6));
+      assertThat(metrics.stream().filter(metricFamilySamples -> metricFamilySamples.type == Collector.Type.GAUGE).count(), is(6L));
+      assertThat(getValue("hikaricp_active_connections", "collectorTestPool"), is(58.0));
+      assertThat(getValue("hikaricp_idle_connections", "collectorTestPool"), is(42.0));
+      assertThat(getValue("hikaricp_pending_threads", "collectorTestPool"), is(1.0));
+      assertThat(getValue("hikaricp_connections", "collectorTestPool"), is(100.0));
+      assertThat(getValue("hikaricp_max_connections", "collectorTestPool"), is(100.0));
+      assertThat(getValue("hikaricp_min_connections", "collectorTestPool"), is(3.0));
+   }
+
+   private Double getValue(String name, String poolName)
+   {
       String[] labelNames = {"pool"};
       String[] labelValues = {poolName};
       return this.collectorRegistry.getSampleValue(name, labelNames, labelValues);
+   }
+
+   private PoolStats poolStatsWithPredefinedValues()
+   {
+      return new PoolStats(0) {
+         @Override
+         protected void update() {
+            totalConnections = 100;
+            idleConnections = 42;
+            activeConnections = 58;
+            pendingThreads = 1;
+            maxConnections = 100;
+            minConnections = 3;
+         }
+      };
    }
 
 }

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactoryTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactoryTest.java
@@ -1,6 +1,7 @@
 package com.zaxxer.hikari.metrics.prometheus;
 
 import com.zaxxer.hikari.metrics.PoolStats;
+import com.zaxxer.hikari.mocks.StubPoolStats;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.After;
@@ -13,30 +14,35 @@ import java.util.List;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class PrometheusMetricsTrackerFactoryTest {
+public class PrometheusMetricsTrackerFactoryTest
+{
+
+   @After
+   public void clearCollectorRegistry()
+   {
+      CollectorRegistry.defaultRegistry.clear();
+   }
 
    @Test
-   public void registersToProvidedCollectorRegistry() {
+   public void registersToProvidedCollectorRegistry()
+   {
       CollectorRegistry collectorRegistry = new CollectorRegistry();
       PrometheusMetricsTrackerFactory factory = new PrometheusMetricsTrackerFactory(collectorRegistry);
-      factory.create("testpool-1", poolStats());
+      factory.create("testpool-1", new StubPoolStats(0));
       assertHikariMetricsAreNotPresent(CollectorRegistry.defaultRegistry);
       assertHikariMetricsArePresent(collectorRegistry);
    }
 
    @Test
-   public void registersToDefaultCollectorRegistry() {
+   public void registersToDefaultCollectorRegistry()
+   {
       PrometheusMetricsTrackerFactory factory = new PrometheusMetricsTrackerFactory();
-      factory.create("testpool-2", poolStats());
+      factory.create("testpool-2", new StubPoolStats(0));
       assertHikariMetricsArePresent(CollectorRegistry.defaultRegistry);
    }
 
-   @After
-   public void clearCollectorRegistry(){
-      CollectorRegistry.defaultRegistry.clear();
-   }
-
-   private void assertHikariMetricsArePresent(CollectorRegistry collectorRegistry) {
+   private void assertHikariMetricsArePresent(CollectorRegistry collectorRegistry)
+   {
       List<String> registeredMetrics = toMetricNames(collectorRegistry.metricFamilySamples());
       assertTrue(registeredMetrics.contains("hikaricp_active_connections"));
       assertTrue(registeredMetrics.contains("hikaricp_idle_connections"));
@@ -46,7 +52,8 @@ public class PrometheusMetricsTrackerFactoryTest {
       assertTrue(registeredMetrics.contains("hikaricp_min_connections"));
    }
 
-   private void assertHikariMetricsAreNotPresent(CollectorRegistry collectorRegistry) {
+   private void assertHikariMetricsAreNotPresent(CollectorRegistry collectorRegistry)
+   {
       List<String> registeredMetrics = toMetricNames(collectorRegistry.metricFamilySamples());
       assertFalse(registeredMetrics.contains("hikaricp_active_connections"));
       assertFalse(registeredMetrics.contains("hikaricp_idle_connections"));
@@ -56,21 +63,12 @@ public class PrometheusMetricsTrackerFactoryTest {
       assertFalse(registeredMetrics.contains("hikaricp_min_connections"));
    }
 
-   private List<String> toMetricNames(Enumeration<Collector.MetricFamilySamples> enumeration) {
+   private List<String> toMetricNames(Enumeration<Collector.MetricFamilySamples> enumeration)
+   {
       List<String> list = new ArrayList<>();
       while (enumeration.hasMoreElements()) {
          list.add(enumeration.nextElement().name);
       }
       return list;
    }
-
-   private PoolStats poolStats() {
-      return new PoolStats(0) {
-         @Override
-         protected void update() {
-            // do nothing
-         }
-      };
-   }
-
 }

--- a/src/test/java/com/zaxxer/hikari/mocks/StubPoolStats.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/StubPoolStats.java
@@ -1,0 +1,20 @@
+package com.zaxxer.hikari.mocks;
+
+import com.zaxxer.hikari.metrics.PoolStats;
+
+public class StubPoolStats extends PoolStats
+{
+
+   public StubPoolStats(long timeoutMs)
+   {
+      super(timeoutMs);
+   }
+
+   @Override
+   protected void update()
+   {
+      // Do nothing
+   }
+
+
+}


### PR DESCRIPTION
…it tests (#1331)

* Refactor/fix Prometheus metrics for multiple connection pools

Changes:
* Fix "Collector already registered that provides name:
hikaricp_connection_timeout_total" error
* Register only one HikariCPCollector instance in one CollectorRegistry
instance
* Add ability to remove metrics when connection pool is shutting down
* Add/update unit tests

* Refactor/add unit tests - metrics package

* Re-format curly braces to be inline with the whole code base